### PR TITLE
Work In Progress

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.DS_Store
+**/.DS_Store
+_env*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# build outputs
+*.pyc
+
+# credentials
+_env*
+manta
+manta.pub
+
+# temp
+python-manta/
+
+# macos frustration
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM mongo-express:0.32
+
+# we need Container Pilot to monitor consul for MongoDB cluster changes so we can update ME_CONFIG_MONGODB_SERVER appropriately
+# "If it is a replica set, use a comma delimited list of the host names."
+
+RUN apt-get update \
+	&& apt-get install -y \
+		ca-certificates \
+		unzip \
+		wget \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV CONTAINERPILOT_VERSION 2.6.0
+ENV CONTAINERPILOT_SHA1 c1bcd137fadd26ca2998eec192d04c08f62beb1f
+RUN set -x \
+	&& wget -O containerpilot.tar.gz "https://github.com/joyent/containerpilot/releases/download/${CONTAINERPILOT_VERSION}/containerpilot-${CONTAINERPILOT_VERSION}.tar.gz" \
+	&& echo "${CONTAINERPILOT_SHA1} *containerpilot.tar.gz" | sha1sum -c - \
+	&& tar -xvf containerpilot.tar.gz -C /usr/local/bin \
+	&& rm -v containerpilot.tar.gz
+
+ENV CONSUL_TEMPLATE_VERSION 0.16.0
+ENV CONSUL_TEMPLATE_SHA256 064b0b492bb7ca3663811d297436a4bbf3226de706d2b76adade7021cd22e156
+RUN set -x \
+	&& wget -O consul-template.zip "https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip" \
+	&& echo "${CONSUL_TEMPLATE_SHA256} *consul-template.zip" | sha256sum -c - \
+	&& unzip consul-template.zip -d /usr/local/bin \
+	&& rm -v consul-template.zip
+
+ENV CONTAINERPILOT file:///etc/containerpilot.json
+
+COPY etc/* /etc/
+COPY bin/* /usr/local/bin/
+
+# override any parent entrypoint
+ENTRYPOINT []
+CMD [ \
+	"containerpilot", \
+# see comment in bin/mongo-express-wrapper.sh for why this is necessary
+	"mongo-express-wrapper.sh", \
+# this is taken from the "mongo-express" default CMD (minus "tini" since we have containerpilot instead)
+	"node", "app" \
+]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,10 @@ COPY bin/* /usr/local/bin/
 
 # override any parent entrypoint
 ENTRYPOINT []
+# see comment in bin/mongo-express-wrapper.sh for why it is necessary
+# "node app" is taken from the "mongo-express" default CMD (no "tini" since we have containerpilot performing those duties instead)
 CMD [ \
 	"containerpilot", \
-# see comment in bin/mongo-express-wrapper.sh for why this is necessary
 	"mongo-express-wrapper.sh", \
-# this is taken from the "mongo-express" default CMD (minus "tini" since we have containerpilot instead)
 	"node", "app" \
 ]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
-# mongo-express
-Work in progress, not stable, expect force pushes of this repo
+# AutoPilot Pattern Mongo Express
+
+*An example implementation of a simple MongoDB application ([Mongo Express](https://github.com/mongo-express/mongo-express)) on top of [AutoPilot Pattern MongoDB](https://github.com/autopilotpattern/mongodb)*
+
+## Architecture
+
+A running cluster includes the following components:
+- [AutoPilot Pattern MongoDB](https://github.com/autopilotpattern/mongodb): for auto-scaling MongoDB via replica sets
+- [ContainerPilot](https://www.joyent.com/containerpilot): included in our Mongo Express container to coordinate runtime configuration rewriting after cluster changes
+- [Consul](https://www.consul.io/): used to coordinate replication and failover
+- [Mongo Express](https://github.com/mongo-express/mongo-express): a simple MongoDB application for browsing/editing the data stored in our cluster
+
+## Running the cluster
+
+Starting a new cluster is easy once you have [your `_env` file set with the configuration details](#configuration)
+
+- for Triton, just run `docker-compose up -d`
+- for non-Triton, just run `docker-compose up -f local-compose.yml -d`
+
+The MongoDB cluster will be initialized according to the process outlined in the [AutoPilot Pattern MongoDB README](https://github.com/autopilotpattern/mongodb/tree/master/README.md), and Mongo Express will be configured to point at all active MongoDB nodes in the cluster (via Consul and ContainerPilot).
+
+**Run `docker-compose -f local-compose.yml scale mongodb=2` to add a replica (or more than one!)**. The replicas will automatically be added to the replica set on the master and will register themselves in Consul as replicas once they're ready, and the Mongo Express configuration will be reloaded to point to the new replicas.
+
+### Configuration
+
+The [configuration items noted for AutoPilot Pattern MongoDB](https://github.com/autopilotpattern/mongodb/blob/master/README.md#configuration) apply for this image as well as the following explicit parameters for this implementation (passed in via `_env` file next to `docker-compose.yml` and `local-compose.yml`):
+
+- `CONSUL` (optional): when using `local-compose.yml`, this will default to `consul` (and thus use the DNS provided by Docker), but for deploying on Triton via `docker-compose.yml`, this should be set to [the CNS path of the `consul` service (`consul.svc.XXX...`)](https://docs.joyent.com/public-cloud/network/cns)
+
+### Sponsors
+
+Initial development of this project was sponsored by [Joyent](https://www.joyent.com).

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The MongoDB cluster will be initialized according to the process outlined in the
 The [configuration items noted for AutoPilot Pattern MongoDB](https://github.com/autopilotpattern/mongodb/blob/master/README.md#configuration) apply for this image as well as the following explicit parameters for this implementation (passed in via `_env` file next to `docker-compose.yml` and `local-compose.yml`):
 
 - `CONSUL` (optional): when using `local-compose.yml`, this will default to `consul` (and thus use the DNS provided by Docker), but for deploying on Triton via `docker-compose.yml`, this should be set to [the CNS path of the `consul` service (`consul.svc.XXX...`)](https://docs.joyent.com/public-cloud/network/cns)
+- any Mongo Express environment variables, such as `ME_CONFIG_OPTIONS_EDITORTHEME` or `ME_CONFIG_MONGODB_ENABLE_ADMIN`; see [the Mongo Express documentation](https://www.npmjs.com/package/mongo-express#usage-docker) for a more complete list
 
 ### Sponsors
 

--- a/bin/mongo-express-wrapper.sh
+++ b/bin/mongo-express-wrapper.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# we can't inject new environment variables directly into Container Pilot, so instead we update/source a file at startup which our co-processes can modify for us
+if [ -f /etc/mongo-express-env ]; then
+	. /etc/mongo-express-env
+fi
+
+exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '2'
+
+services:
+
+    mongo-express:
+        extends:
+            file: local-compose.yml
+            service: mongo-express
+        labels:
+            - triton.cns.services=mongo-express
+        network_mode: bridge
+
+    mongodb:
+        extends:
+            file: local-compose.yml
+            service: mongodb
+        mem_limit: 4g
+        labels:
+            - triton.cns.services=mongod
+        network_mode: bridge
+
+    consul:
+        extends:
+            file: local-compose.yml
+            service: consul
+        labels:
+            - triton.cns.services=consul
+        network_mode: bridge

--- a/etc/containerpilot.json
+++ b/etc/containerpilot.json
@@ -1,0 +1,30 @@
+{
+	"consul": "{{ .CONSUL }}:8500",
+	"preStart": [
+		"consul-template",
+		"-once",
+		"-consul", "{{ .CONSUL }}:8500",
+		"-template", "/etc/mongo-express-env.ctmpl:/etc/mongo-express-env"
+	],
+	"services": [
+		{
+			"name": "mongo-express",
+			"port": 8081,
+			"health": "wget -q -O /dev/null http://localhost:8081",
+			"poll": 5,
+			"ttl": 25
+		}
+	],
+	"backends": [
+		{
+			"name": "mongodb-replicaset",
+			"poll": 5,
+			"onChange": [
+				"consul-template",
+				"-once",
+				"-consul", "{{ .CONSUL }}:8500",
+				"-template", "/etc/mongo-express-env.ctmpl:/etc/mongo-express-env:kill -TERM 1"
+			]
+		}
+	]
+}

--- a/etc/containerpilot.json
+++ b/etc/containerpilot.json
@@ -1,9 +1,9 @@
 {
-	"consul": "{{ .CONSUL }}:8500",
+	"consul": "{{ if .CONSUL }}{{ .CONSUL }}{{ else }}consul{{ end }}:8500",
 	"preStart": [
 		"consul-template",
 		"-once",
-		"-consul", "{{ .CONSUL }}:8500",
+		"-consul", "{{ if .CONSUL }}{{ .CONSUL }}{{ else }}consul{{ end }}:8500",
 		"-template", "/etc/mongo-express-env.ctmpl:/etc/mongo-express-env"
 	],
 	"services": [
@@ -22,7 +22,7 @@
 			"onChange": [
 				"consul-template",
 				"-once",
-				"-consul", "{{ .CONSUL }}:8500",
+				"-consul", "{{ if .CONSUL }}{{ .CONSUL }}{{ else }}consul{{ end }}:8500",
 				"-template", "/etc/mongo-express-env.ctmpl:/etc/mongo-express-env:kill -TERM 1"
 			]
 		}

--- a/etc/mongo-express-env.ctmpl
+++ b/etc/mongo-express-env.ctmpl
@@ -1,0 +1,8 @@
+{{- if service "mongodb-replicaset" -}}
+export ME_CONFIG_MONGODB_SERVER="
+	{{- range $i, $e := service "mongodb-replicaset" -}}
+		{{- if ne $i 0 -}} , {{- end -}}
+		{{ $e.Address }}
+	{{- end -}}
+"
+{{ end -}}

--- a/local-compose.yml
+++ b/local-compose.yml
@@ -1,0 +1,42 @@
+version: '2'
+
+services:
+
+    mongo-express:
+        image: autopilotpattern/mongo-express
+        build: .
+        restart: always
+        mem_limit: 512m
+        environment:
+            - CONSUL=consul
+            - ME_CONFIG_OPTIONS_EDITORTHEME=ambiance
+# ME_CONFIG_MONGODB_SERVER will get re-written by consul-template
+            - ME_CONFIG_MONGODB_SERVER=mongodb
+        ports:
+            - 8081
+
+    mongodb:
+        image: autopilotpattern/mongodb
+        command: containerpilot mongod --replSet=pilot
+        restart: always
+        mem_limit: 512m
+        env_file: _env
+        environment:
+            - CONSUL=consul
+        ports:
+            - 27017
+
+    consul:
+        image: consul:0.7.1
+        command: agent -dev -ui -client=0.0.0.0
+        restart: always
+        mem_limit: 128m
+        ports:
+            - 8500
+        expose:
+            - 53
+            - 8300
+            - 8301
+            - 8302
+            - 8400
+            - 8500

--- a/local-compose.yml
+++ b/local-compose.yml
@@ -7,8 +7,8 @@ services:
         build: .
         restart: always
         mem_limit: 512m
+        env_file: _env
         environment:
-            - CONSUL=consul
             - ME_CONFIG_OPTIONS_EDITORTHEME=ambiance
 # ME_CONFIG_MONGODB_SERVER will get re-written by consul-template
             - ME_CONFIG_MONGODB_SERVER=mongodb
@@ -21,8 +21,6 @@ services:
         restart: always
         mem_limit: 512m
         env_file: _env
-        environment:
-            - CONSUL=consul
         ports:
             - 27017
 


### PR DESCRIPTION
This currently depends on https://github.com/autopilotpattern/mongodb/pull/7 being merged to work locally.

We also currently rely on Docker's restart policy to make sure we come back up after configuration changes due to `mongo-express` wanting the full list of replica set members (having annoying failure modes when talking to a non-primary), but accepting that configuration value via an environment variable and requiring an application restart (ie, https://github.com/joyent/containerpilot/issues/126).