### PR TITLE
Latest express & minor updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo-express:0.32
+FROM mongo-express:0.38
 
 # we need Container Pilot to monitor consul for MongoDB cluster changes so we can update ME_CONFIG_MONGODB_SERVER appropriately
 # "If it is a replica set, use a comma delimited list of the host names."

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Starting a new cluster is easy once you have [your `_env` file set with the conf
 **Triton**
 - `./setup.sh`
 - `docker-compose up -d`
-- `open $(triton ip mongoexpress_mongo-express_1):8081`
+- `open http://$(triton ip mongoexpress_mongo-express_1):8081`
 
 **Local (or Non-Triton)**
 - `docker-compose up -f local-compose.yml -d`
-- `open localhost:<assigned port>`
+- `open http://localhost:8081`
 
 The `setup.sh` script will check that your environment is setup correctly and will create an `_env` file that includes injecting an environment variable for the Consul hostname into the Mongo and Mongo-Express containers so we can take advantage of [Triton Container Name Service (CNS)](https://www.joyent.com/blog/introducing-triton-container-name-service).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,20 @@
 version: '2'
 
 services:
-
     mongo-express:
-        extends:
-            file: local-compose.yml
-            service: mongo-express
+        image: autopilotpattern/mongo-express
+        restart: always
+        mem_limit: "512m"
+        environment:
+            - ME_CONFIG_OPTIONS_EDITORTHEME=ambiance
+            # ME_CONFIG_MONGODB_SERVER will get re-written by consul-template
+            - ME_CONFIG_MONGODB_SERVER=mongodb
         labels:
             - triton.cns.services=mongo-express
         network_mode: bridge
-
+        env_file: _env
+        ports:
+          - 8081
     mongodb:
         extends:
             file: local-compose.yml
@@ -18,7 +23,7 @@ services:
         labels:
             - triton.cns.services=mongod
         network_mode: bridge
-
+        env_file: _env
     consul:
         extends:
             file: local-compose.yml

--- a/local-compose.yml
+++ b/local-compose.yml
@@ -1,29 +1,24 @@
 version: '2'
 
 services:
-
     mongo-express:
         image: autopilotpattern/mongo-express
         build: .
         restart: always
         mem_limit: 512m
-        env_file: _env
         environment:
             - ME_CONFIG_OPTIONS_EDITORTHEME=ambiance
-# ME_CONFIG_MONGODB_SERVER will get re-written by consul-template
+            # ME_CONFIG_MONGODB_SERVER will get re-written by consul-template
             - ME_CONFIG_MONGODB_SERVER=mongodb
         ports:
-            - 8081
-
+            - "8081:8081"
     mongodb:
         image: autopilotpattern/mongodb
         command: containerpilot mongod --replSet=pilot
         restart: always
         mem_limit: 512m
-        env_file: _env
         ports:
             - 27017
-
     consul:
         image: consul:0.7.2
         command: agent -dev -ui -client=0.0.0.0


### PR DESCRIPTION
- Map to port 8081 for local-compose
- Pull from hub instead of doing a build when running on triton
- Do not require `_env` file for local-compose